### PR TITLE
Warn about SEO Prefix and not set when delivery type is fetch

### DIFF
--- a/packages/url-loader/src/plugins/seo.ts
+++ b/packages/url-loader/src/plugins/seo.ts
@@ -9,7 +9,11 @@ export function plugin(props: PluginSettings) {
   const { seoSuffix } = options;
 
   if ( typeof seoSuffix === 'string' ) {
-    cldImage.setSuffix(seoSuffix);
+    if ( options.deliveryType === 'fetch' ) {
+      console.warn('SEO suffix is not supported with a delivery type of fetch')
+    } else {
+      cldImage.setSuffix(seoSuffix);
+    }
   }
 
   return {};

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -140,14 +140,16 @@ describe('Cloudinary', () => {
         const cloudName = 'customtestcloud';
         const assetType = 'images';
         const publicId = 'myimage/my-image';
+        const width = 1234;
+        const height = 1234;
 
-        const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
+        const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_${width}/f_auto/q_auto/v1234/${publicId}?_a=A`;
 
         const url = constructCloudinaryUrl({
           options: {
             src,
-            width: 100,
-            height: 100,
+            width,
+            height,
           },
           config: {
             cloud: {
@@ -157,6 +159,35 @@ describe('Cloudinary', () => {
         });
 
         expect(url).toContain(src);
+      });
+
+      it('should create a NON-SEO prefixed Cloudinary URL from a Cloudinary source with SEO prefixes when delivery type is fetch', () => {
+        const cloudName = 'customtestcloud';
+        const assetType = 'images';
+        const publicId = 'colby-hug';
+        const seoSuffix = 'colby-hug';
+        const format = '.jpg';
+        const width = 1234;
+        const height = 1234;
+
+        const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_${width}/f_auto/q_auto/v1234/${publicId}/${seoSuffix}${format}?_i=A`;
+        const exepectedSrc = `https://res.cloudinary.com/${cloudName}/image/fetch/c_limit,w_${width}/f_auto/q_auto/v1234/${publicId}?_a=A`
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            width,
+            height,
+            deliveryType: 'fetch'
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+
+        expect(url).toContain(exepectedSrc);
       });
 
       it('should create a Cloudinary URL from a Cloudinary source with SEO prefixes and overriding', () => {


### PR DESCRIPTION
# Description

Delivery type fetch and SEO prefix can't work together, so if the fetch delivery type is found, it does not set the SEO prefix and instead warns.

## Issue Ticket Number

Fixes #28 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
