### PR TITLE
Fixes Secure Distributions (CNAMEs) from not being parsed

### DIFF
--- a/packages/util/src/lib/cloudinary.ts
+++ b/packages/util/src/lib/cloudinary.ts
@@ -3,6 +3,7 @@ const REGEX_FORMAT = /\.(ai|avif|gif|png|webp|bmp|bw|djvu|dng|ps|ept|eps|eps3|fb
 const REGEX_URL = /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)?\/?(?<assetType>image|images|video|videos|raw|files)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)?\/?(?<signature>s--([a-zA-Z0-9\_\-]{8}|[a-zA-Z0-9\_\-]{32})--)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?\/?)*\/)*(?<version>v\d+|\w{1,2})\/(?<publicId>[^\s]+)$/;
 const ASSET_TYPES_SEO = ['images', 'videos', 'files'];
 
+const CLOUDINARY_DEFAULT_HOST = 'res.cloudinary.com';
 
 /**
  * parseUrl
@@ -55,6 +56,10 @@ export function parseUrl(src: string): ParseUrl | undefined {
     transformations: transformations || [],
     queryParams: {},
     version: results?.groups?.version ? parseInt(results.groups.version.replace('v', '')) : undefined
+  }
+
+  if ( parts.host === CLOUDINARY_DEFAULT_HOST && !parts.cloudName ) {
+    throw new Error('Invalid src: Cloudinary URL delivered from res.cloudinary.com must include Cloud Name (ex: res.cloudinary.com/<Cloud Name>/image/...)')
   }
 
   if ( queryString ) {

--- a/packages/util/src/lib/cloudinary.ts
+++ b/packages/util/src/lib/cloudinary.ts
@@ -1,6 +1,6 @@
 const REGEX_VERSION = /\/v\d+\//;
 const REGEX_FORMAT = /\.(ai|avif|gif|png|webp|bmp|bw|djvu|dng|ps|ept|eps|eps3|fbx|flif|gif|glb|gltf|heif|heic|ico|indd|jpg|jpe|jpeg|jp2|wdp|jxr|hdp|obj|pdf|ply|png|psd|arw|cr2|svg|tga|tif|tiff|u3ma|usdz|webp|3g2|3gp|avi|flv|m3u8|ts|m2ts|mts|mov|mkv|mp4|mpeg|mpd|mxf|ogv|webm|wmv)$/i
-const REGEX_URL = /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)\/(?<assetType>image|images|video|videos|raw|files)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)?\/?(?<signature>s--([a-zA-Z0-9\_\-]{8}|[a-zA-Z0-9\_\-]{32})--)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?\/?)*\/)*(?<version>v\d+|\w{1,2})\/(?<publicId>[^\s]+)$/;
+const REGEX_URL = /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)?\/?(?<assetType>image|images|video|videos|raw|files)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)?\/?(?<signature>s--([a-zA-Z0-9\_\-]{8}|[a-zA-Z0-9\_\-]{32})--)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?\/?)*\/)*(?<version>v\d+|\w{1,2})\/(?<publicId>[^\s]+)$/;
 const ASSET_TYPES_SEO = ['images', 'videos', 'files'];
 
 

--- a/packages/util/tests/lib/cloudinary.spec.js
+++ b/packages/util/tests/lib/cloudinary.spec.js
@@ -322,6 +322,18 @@ describe('Cloudinary', () => {
         version,
       })
     });
+
+    it('should throw an error if delivering from res.cloudinary.com without a cloud name', () => {
+      const assetType = 'image';
+      const deliveryType = 'upload';
+      const host = 'res.cloudinary.com';
+      const publicId = 'asdf';
+      const version = 1234;
+
+      const src = `http://${host}/${assetType}/${deliveryType}/v${version}/${publicId}`;
+
+      expect(() => parseUrl(src)).toThrowError('Cloudinary URL delivered from res.cloudinary.com must include Cloud Name (ex: res.cloudinary.com/<Cloud Name>/image/...)');
+    });
   });
 
   describe('getPublicId', () => {

--- a/packages/util/tests/lib/cloudinary.spec.js
+++ b/packages/util/tests/lib/cloudinary.spec.js
@@ -284,6 +284,44 @@ describe('Cloudinary', () => {
         version,
       })
     });
+
+    it('should parse a Cloudinary URL with a secure distribution with private CDN', () => {
+      const assetType = 'image';
+      const deliveryType = 'upload';
+      const host = 'assets.mycoolsite.com';
+      const publicId = 'asdf';
+      const version = 1234;
+
+      const src = `http://${host}/${assetType}/${deliveryType}/v${version}/${publicId}`;
+
+      expect(parseUrl(src)).toMatchObject({
+        assetType,
+        deliveryType,
+        host,
+        publicId,
+        version,
+      })
+    });
+
+    it('should parse a Cloudinary URL with a secure distribution including a cloud name', () => {
+      const assetType = 'image';
+      const cloudName = 'test-cloud';
+      const deliveryType = 'upload';
+      const host = 'assets.mycoolsite.com';
+      const publicId = 'asdf';
+      const version = 1234;
+
+      const src = `http://${host}/${cloudName}/${assetType}/${deliveryType}/v${version}/${publicId}`;
+
+      expect(parseUrl(src)).toMatchObject({
+        assetType,
+        cloudName,
+        deliveryType,
+        host,
+        publicId,
+        version,
+      })
+    });
   });
 
   describe('getPublicId', () => {


### PR DESCRIPTION
# Description

URLs that include a CNAME are failing to be parsed. This makes the cloud name optional in cases where the hostname is not res.cloudinary.com to support that pattern.

## Issue Ticket Number

Related https://github.com/cloudinary-community/next-cloudinary/issues/479

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
