### PR TITLE
feat: added Zod schema for the effects array in the overlay schema

### DIFF
--- a/packages/url-loader/src/plugins/overlays.ts
+++ b/packages/url-loader/src/plugins/overlays.ts
@@ -20,6 +20,7 @@ import {
 import { constructTransformation } from "../lib/transformations.js";
 import type { TransformationPlugin } from "../types/plugins.js";
 import type { Qualifier } from "../types/qualifiers.js";
+import { effectsProps } from "./effects.js";
 
 const overlayTextSchema = z.object({
   alignment: z.string().optional(),
@@ -47,7 +48,7 @@ const overlayPositionSchema = z.object({
 const overlaySchema = z.object({
   appliedEffects: z.array(z.object({})).optional(),
   appliedFlags: flags.schema.optional(),
-  effects: z.array(z.object({})).optional(),
+  effects: z.array(z.object(effectsProps)).optional(),
   crop: crop.schema.optional(),
   flags: flags.schema.optional(),
   height: height.schema.optional(),


### PR DESCRIPTION
# Description

This PR adds the effect schema to the effects property of an overlay. Prior to the change, it was an empty object.

It was mentioned in #169 to update the effects with radius into [main/packages/url-loader/src/constants/qualifiers.ts#L90](https://github.com/cloudinary-community/cloudinary-util/blob/main/packages/url-loader/src/constants/qualifiers.ts?rgh-link-date=2024-08-13T01%3A52%3A11Z#L90), but the radius schema is already in there.

From what I can tell, only the overlay schema needed to be updated. Side note, but this doesn't just fix the issue with radius not being found, but adds all the available effects settings to the overlay effects array schema. I'm assuming that all effects are available in an overlay @colbyfayock, or is it only a subset of effects that are available to overlays?

~I marked this as a breaking change in case anyone using the cloudinary-util package has a value which is not in the newly introduced Zod enum, as previously it was any string. If that is the case, that gravity option probably never worked for them, but just erring on the safe side for a release.~

I haven't made any documentation updates here as there does not appear to be any docs related to the options including gravity, but if there is a separate repository that requires a documentation update, happy to make changes there as well.

## Issue Ticket Number

Closes #169

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
