### PR TITLE
Fixes undefined aspect ratio `undefined:undefined` with no width or height

### DIFF
--- a/packages/url-loader/src/lib/video-player.ts
+++ b/packages/url-loader/src/lib/video-player.ts
@@ -43,7 +43,6 @@ export function getVideoPlayerOptions(
   const {
     autoplay,
     controls = true,
-    height,
     language,
     languages,
     logo = true,
@@ -53,7 +52,6 @@ export function getVideoPlayerOptions(
     src,
     transformation,
     quality = "auto",
-    width,
     ...otherCldVidPlayerOptions
   } = options;
 
@@ -160,13 +158,14 @@ export function getVideoPlayerOptions(
     loop,
     muted,
     publicId,
-    width,
-    height,
-    aspectRatio: `${width}:${height}`,
     transformation: playerTransformations,
     ...logoOptions,
     ...otherCldVidPlayerOptions,
   };
+
+  if ( playerOptions.width && playerOptions.height && !playerOptions.aspectRatio ) {
+    playerOptions.aspectRatio = `${playerOptions.width}:${playerOptions.height}`;
+  }
 
   if (typeof poster === "string") {
     // If poster is a string, assume it's either a public ID

--- a/packages/url-loader/tests/lib/video-player.spec.js
+++ b/packages/url-loader/tests/lib/video-player.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { getVideoPlayerOptions } from '../../src/lib/video-player';
 
@@ -11,13 +11,13 @@ describe('video-player', () => {
           height: '1080',
           src: 'videos/mountain-stars',
         }
-        
+
         const config = {
           cloud: {
             cloudName: 'testcloud'
           }
         };
-  
+
         const expectedOptions = {
           aspectRatio: '1620:1080',
           autoplay: false,
@@ -39,8 +39,85 @@ describe('video-player', () => {
           ],
           width: '1620',
         }
-  
+
         expect(getVideoPlayerOptions(options, config)).toMatchObject(expectedOptions)
+      });
+
+      it('should return create an options object without a width or height', () => {
+        const options = {
+          src: 'videos/mountain-stars',
+        }
+
+        const config = {
+          cloud: {
+            cloudName: 'testcloud'
+          }
+        };
+
+        const expectedOptions = {
+          autoplay: false,
+          autoplayMode: undefined,
+          cloud_name: 'testcloud',
+          controls: true,
+          language: undefined,
+          languages: undefined,
+          loop: false,
+          muted: false,
+          privateCdn: undefined,
+          publicId: 'videos/mountain-stars',
+          secureDistribution: undefined,
+          showLogo: true,
+          transformation: [
+            { quality: 'auto' },
+            undefined
+          ],
+        }
+
+        const playerOptions = getVideoPlayerOptions(options, config);
+
+        expect(playerOptions).toMatchObject(expectedOptions);
+        expect(playerOptions.width).toBeUndefined();
+        expect(playerOptions.height).toBeUndefined();
+        expect(playerOptions.aspectRatio).toBeUndefined();
+      });
+
+      it('should return create an options object with only an aspect ratio', () => {
+        const options = {
+          src: 'videos/mountain-stars',
+          aspectRatio: '16:9'
+        }
+
+        const config = {
+          cloud: {
+            cloudName: 'testcloud'
+          }
+        };
+
+        const expectedOptions = {
+          aspectRatio: options.aspectRatio,
+          autoplay: false,
+          autoplayMode: undefined,
+          cloud_name: 'testcloud',
+          controls: true,
+          language: undefined,
+          languages: undefined,
+          loop: false,
+          muted: false,
+          privateCdn: undefined,
+          publicId: 'videos/mountain-stars',
+          secureDistribution: undefined,
+          showLogo: true,
+          transformation: [
+            { quality: 'auto' },
+            undefined
+          ],
+        }
+
+        const playerOptions = getVideoPlayerOptions(options, config);
+
+        expect(playerOptions).toMatchObject(expectedOptions);
+        expect(playerOptions.width).toBeUndefined();
+        expect(playerOptions.height).toBeUndefined();
       });
 
       it('should configure custom quality', () => {
@@ -50,13 +127,13 @@ describe('video-player', () => {
           src: 'videos/mountain-stars',
           quality: 50,
         }
-        
+
         const config = {
           cloud: {
             cloudName: 'testcloud'
           }
         };
-  
+
         expect(getVideoPlayerOptions(options, config)).toMatchObject({
           transformation: [
             { quality: options.quality },
@@ -65,7 +142,7 @@ describe('video-player', () => {
         })
       });
     })
-    
+
     describe('Playback', () => {
       it('should configure ABR via source types', () => {
         const options = {
@@ -77,13 +154,13 @@ describe('video-player', () => {
           },
           sourceTypes: ['hls'],
         }
-        
+
         const config = {
           cloud: {
             cloudName: 'testcloud'
           }
         };
-    
+
         expect(getVideoPlayerOptions(options, config)).toMatchObject({
           transformation: [
             { quality: 'auto' },
@@ -111,7 +188,7 @@ describe('video-player', () => {
             text: '#0000ff'
           }
         }
-        
+
         const config = {
           cloud: {
             cloudName: 'testcloud'
@@ -134,7 +211,7 @@ describe('video-player', () => {
           src: 'videos/mountain-stars',
           poster: 'string'
         }
-        
+
         const config = {
           cloud: {
             cloudName: 'testcloud'
@@ -155,7 +232,7 @@ describe('video-player', () => {
             tint: 'equalize:80:blue:blueviolet'
           }
         }
-        
+
         const config = {
           cloud: {
             cloudName: 'testcloud'
@@ -177,7 +254,7 @@ describe('video-player', () => {
             tint: 'equalize:80:blue:blueviolet'
           }
         }
-        
+
         const config = {
           cloud: {
             cloudName: 'testcloud'


### PR DESCRIPTION
# Description

When using getVideoPlayerOptions without a width or height, the returned options object would include an aspect ratio as `undefined:undefined`.

This checks to see the existence of the width and height values before trying to use them in the aspect ratio.

## Issue Ticket Number

Fixes #176 

https://github.com/cloudinary-community/next-cloudinary/issues/499

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
