### PR TITLE
v5.7.0

### DIFF
--- a/packages/url-loader/CHANGELOG.md
+++ b/packages/url-loader/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [@cloudinary-util/url-loader-v5.7.0-beta.1](https://github.com/cloudinary-community/cloudinary-util/compare/@cloudinary-util/url-loader-v5.6.1...@cloudinary-util/url-loader-v5.7.0-beta.1) (2024-08-21)
+
+
+### Features
+
+* Using /types to import Config Options ([#178](https://github.com/cloudinary-community/cloudinary-util/issues/178)) ([d3763e6](https://github.com/cloudinary-community/cloudinary-util/commit/d3763e65af42493dfdcd4010cbd0ded96acdd063))
+
 # [@cloudinary-util/url-loader-v5.6.1](https://github.com/cloudinary-community/cloudinary-util/compare/@cloudinary-util/url-loader-v5.6.0...@cloudinary-util/url-loader-v5.6.1) (2024-08-21)
 
 

--- a/packages/url-loader/package.json
+++ b/packages/url-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudinary-util/url-loader",
-  "version": "5.6.1",
+  "version": "5.7.0-beta.1",
   "type": "module",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",

--- a/packages/url-loader/src/index.ts
+++ b/packages/url-loader/src/index.ts
@@ -41,7 +41,7 @@ export type {
 } from "./types/analytics.js";
 export type { AssetOptions } from "./types/asset.js";
 export type {
-  CloudinaryConfigurationOptions, ConfigOptions
+  ConfigOptions
 } from "./types/config.js";
 export type { ImageOptions } from "./types/image.js";
 export type {

--- a/packages/url-loader/src/types/config.ts
+++ b/packages/url-loader/src/types/config.ts
@@ -1,10 +1,7 @@
+import type { CloudinaryAssetConfiguration } from "@cloudinary-util/types";
 import { z } from "zod";
-import type ICloudinaryConfigurations from "@cloudinary/url-gen/config/interfaces/Config/ICloudinaryAssetConfigurations";
 
-export interface CloudinaryConfigurationOptions
-  extends ICloudinaryConfigurations {}
-
-export const configOptionsSchema: z.ZodType<CloudinaryConfigurationOptions> =
+export const configOptionsSchema: z.ZodType<CloudinaryAssetConfiguration> =
   z.any();
 
 export type ConfigOptions = z.TypeOf<typeof configOptionsSchema>;


### PR DESCRIPTION
# Description

Copies over the Config options types from the url-gen package and exposes them as first class from the /types package to help resolve upstream issues.