### PR TITLE
Adds preserveTransformations to URL Loader

### DIFF
--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -15,12 +15,13 @@ import { fillBackgroundPlugin } from "../plugins/fill-background.js";
 import { flagsPlugin } from "../plugins/flags.js";
 import { namedTransformationsPlugin } from "../plugins/named-transformations.js";
 import { overlaysPlugin } from "../plugins/overlays.js";
+import { preserveTransformationsPlugin } from "../plugins/preserve-transformations.js";
 import { rawTransformationsPlugin } from "../plugins/raw-transformations.js";
 import { recolorPlugin } from "../plugins/recolor.js";
 import { removeBackgroundPlugin } from "../plugins/remove-background.js";
 import { removePlugin } from "../plugins/remove.js";
-import { replacePlugin } from "../plugins/replace.js";
 import { replaceBackgroundPlugin } from "../plugins/replace-background.js";
+import { replacePlugin } from "../plugins/replace.js";
 import { restorePlugin } from "../plugins/restore.js";
 import { sanitizePlugin } from "../plugins/sanitize.js";
 import { seoPlugin } from "../plugins/seo.js";
@@ -62,6 +63,7 @@ export const transformationPlugins = [
   // other arguments to avoid conflicting with
   // added options via the component
 
+  preserveTransformationsPlugin,
   rawTransformationsPlugin,
 
   abrPlugin,

--- a/packages/url-loader/src/plugins/preserve-transformations.ts
+++ b/packages/url-loader/src/plugins/preserve-transformations.ts
@@ -1,0 +1,40 @@
+import { getTransformations } from "@cloudinary-util/util";
+import { boolean, z } from "zod";
+import type { TransformationPlugin } from "../types/plugins.js";
+
+export const preserveTransformationsProps = {
+  preserveTransformations: z
+    .boolean()
+    .describe(
+      JSON.stringify({
+        text: "Array of transformation parameters using the Cloudinary URL API to apply to an asset.",
+        url: "https://cloudinary.com/documentation/transformation_reference",
+      })
+    )
+    .optional(),
+};
+
+export const preserveTransformationsPlugin = {
+  props: preserveTransformationsProps,
+  assetTypes: ["image", "images", "video", "videos"],
+  plugin: ({ cldAsset, options }) => {
+    let { preserveTransformations = false } = options;
+
+    // Try to preserve the original transformations from the Cloudinary URL passed in
+    // to the component. This only works if the URL has a version number on it and otherwise
+    // will fail to load
+
+    if (preserveTransformations) {
+      try {
+        const transformations = getTransformations(options.src).map(t => t.join(','));
+        transformations.flat().forEach((transformation) => {
+          cldAsset.addTransformation(transformation);
+        });
+      } catch(e) {
+        console.warn(`Failed to preserve transformations: ${(e as Error).message}`)
+      }
+    }
+
+    return {};
+  },
+} satisfies TransformationPlugin;

--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -4,6 +4,7 @@ import { effectsProps } from "../plugins/effects.js";
 import { flagsProps } from "../plugins/flags.js";
 import { namedTransformationsProps } from "../plugins/named-transformations.js";
 import { overlaysProps } from "../plugins/overlays.js";
+import { preserveTransformationsProps } from "../plugins/preserve-transformations.js";
 import { rawTransformationsProps } from "../plugins/raw-transformations.js";
 import { removeBackgroundProps } from "../plugins/remove-background.js";
 import { sanitizeProps } from "../plugins/sanitize.js";
@@ -101,6 +102,7 @@ export const assetOptionsSchema = z.object({
   ...flagsProps,
   ...namedTransformationsProps,
   ...overlaysProps,
+  ...preserveTransformationsProps,
   ...rawTransformationsProps,
   ...removeBackgroundProps,
   ...sanitizeProps,

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, afterEach } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { constructCloudinaryUrl } from '../../src/lib/cloudinary';
 
@@ -568,6 +568,36 @@ describe('Cloudinary', () => {
         expect(url).not.toContain(`?_a`);
       });
 
+    });
+
+    /* Raw Transformations */
+
+    describe('preserveTransformations', () => {
+      it('should preserve transformations with additional properties', () => {
+        const cloudName = 'customtestcloud';
+        const publicId = 'turtle';
+        const version = 1234;
+        const transformations = ['c_limit,w_100', 'f_auto', 'q_auto'];
+        const existingUrl = `https://res.cloudinary.com/${cloudName}/image/upload/${transformations.join('/')}/v${version}/${publicId}`;
+
+        const opacity = 12;
+        const shear = '40:10';
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src: existingUrl,
+            opacity,
+            effects: [{ shear }],
+            preserveTransformations: true
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+        expect(url).toContain(`image/upload/${transformations.join('/')}/o_${opacity}/e_shear:${shear}/v${version}/${publicId}`);
+      });
     });
 
     /* Raw Transformations */

--- a/packages/url-loader/tests/plugins/preserve-transformations.spec.js
+++ b/packages/url-loader/tests/plugins/preserve-transformations.spec.js
@@ -1,0 +1,40 @@
+import { Cloudinary } from '@cloudinary/url-gen';
+import { describe, expect, it } from 'vitest';
+
+import { preserveTransformationsPlugin } from '../../src/plugins/preserve-transformations';
+
+const { plugin } = preserveTransformationsPlugin
+
+const cloudName = 'test-cloud-name';
+
+const cld = new Cloudinary({
+  cloud: {
+    cloudName
+  }
+});
+
+const TEST_PUBLIC_ID = 'test-public-id';
+
+describe('Plugins', () => {
+  describe('Preserve Transformations', () => {
+    it('should preserve transformations from an existing URL ', () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const cloudName = 'customtestcloud';
+      const transformations = ['c_limit,w_100', 'f_auto', 'q_auto'];
+      const url = `https://res.cloudinary.com/${cloudName}/image/upload/${transformations.join('/')}/v1234/turtle`;
+
+      const options = {
+        src: url,
+        preserveTransformations: true
+      }
+
+      plugin({
+        cldAsset: cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`/image/upload/${transformations.join('/')}/`);
+    });
+  });
+});


### PR DESCRIPTION
# Description

`preserveTransformations` is an option currently maintained at the framework level that reads transformations from a Cloudinary URL as the source and applies them, which by default, only uses the public ID from that URL.

From what I can tell there's no reason that this needs to be maintained at the framework level and can instead be maintained with the rest of the URL Loader logic.

Simply `preserveTransformations` when passing a `src` as a Cloudinary URL with a version # (required).

## Issue Ticket Number

Fixes #183 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
