### PR TITLE
Crop by X and Y Coordinates

### DIFF
--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -6,6 +6,8 @@ import {
   gravity,
   height,
   width,
+  x,
+  y,
   zoom,
 } from "../constants/parameters.js";
 import type { AssetOptions } from "./asset.js";
@@ -39,6 +41,8 @@ export const pluginOptionsSchema = z.object({
   height: height.schema.optional(),
   format: format.schema.optional(),
   resize: z.string().optional(),
+  x: x.schema.optional(),
+  y: y.schema.optional(),
   width: width.schema.optional(),
   zoom: zoom.schema.optional(),
 });

--- a/packages/url-loader/tests/plugins/cropping.spec.js
+++ b/packages/url-loader/tests/plugins/cropping.spec.js
@@ -66,7 +66,6 @@ describe('Cropping plugin', () => {
         type: 'thumb'
       }
     };
-
     const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toContain(`c_${options.crop.type},w_${options.crop.width},h_${options.crop.height},g_auto`);
   });
@@ -234,4 +233,72 @@ describe('Cropping plugin', () => {
     const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toBeUndefined();
   });
+
+  it('should apply coordinates-based cropping with x and y with no default gravity', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 123,
+      height: 321,
+      crop: {
+        type: 'crop',
+        x: 50,
+        y: 100
+      }
+    };
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toBe(`c_${options.crop.type},w_${options.width},h_${options.height},x_${options.crop.x},y_${options.crop.y}`);
+  });
+
+  it('should apply coordinates-based cropping with custom gravity', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 123,
+      height: 321,
+      crop: {
+        type: 'crop',
+        x: 4321,
+        y: 1234,
+        gravity: 'south'
+      }
+    };
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toBe(`c_${options.crop.type},w_${options.width},h_${options.height},x_${options.crop.x},y_${options.crop.y},g_${options.crop.gravity}`);
+  });
+
+  it('should apply coordinates-based cropping with custom width and height', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 123,
+      height: 321,
+      crop: {
+        type: 'crop',
+        x: 100,
+        y: 100,
+        width: 567,
+        height: 765,
+        gravity: 'south'
+      }
+    };
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toBe(`c_${options.crop.type},w_${options.crop.width},h_${options.crop.height},x_${options.crop.x},y_${options.crop.y},g_${options.crop.gravity}`);
+  });
+
+  it('should crop by coordinates in 2 stages with width', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 900,
+      height: 600,
+      crop: {
+        type: 'fill',
+        x: 5687,
+        y: 6543,
+        source: true
+      }
+    };
+
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toContain(`c_limit,w_${options.width}`);
+    expect(cldImage.toURL()).toContain(`image/upload/c_${options.crop.type},w_${options.width},h_${options.height},x_${options.crop.x},y_${options.crop.y}`);
+  });
 });
+


### PR DESCRIPTION
# Description

Adds the x and y coordinate options to the crop plugin to allow for coordinates based crops.

```
width: 123,
height: 321,
crop: {
  type: 'crop',
  x: 123
  y: 321
}
```

## Issue Ticket Number


https://github.com/cloudinary-community/next-cloudinary/issues/481

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
