### PR TITLE
fix: export the new widget types

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,8 +1,13 @@
 export type {
-  CloudinaryResource, CloudinaryResourceAccessMode, CloudinaryResourceResourceType, CloudinaryResourceType
+  CloudinaryResource,
+  CloudinaryResourceAccessMode,
+  CloudinaryResourceResourceType,
+  CloudinaryResourceType,
 } from "./types/resources.js";
 
 export type {
+  CloudinaryCreateUploadWidget,
+  CloudinaryUploadWidget,
   CloudinaryUploadWidgetError,
   CloudinaryUploadWidgetInfo,
   CloudinaryUploadWidgetInstanceMethodCloseOptions,
@@ -12,7 +17,7 @@ export type {
   CloudinaryUploadWidgetInstanceMethods,
   CloudinaryUploadWidgetOptions,
   CloudinaryUploadWidgetResults,
-  CloudinaryUploadWidgetSources
+  CloudinaryUploadWidgetSources,
 } from "./types/cloudinary-upload-widget.js";
 
 export type {
@@ -20,10 +25,12 @@ export type {
   CloudinaryVideoPlayerOptionPosterOptions,
   CloudinaryVideoPlayerOptions,
   CloudinaryVideoPlayerOptionsColors,
-  CloudinaryVideoPlayerOptionsLogo
+  CloudinaryVideoPlayerOptionsLogo,
 } from "./types/cloudinary-video-player.js";
 
 export type {
-  CloudinaryAssetConfiguration, CloudinaryAssetConfigurationAuthToken, CloudinaryAssetConfigurationCloud, CloudinaryAssetConfigurationUrl
+  CloudinaryAssetConfiguration,
+  CloudinaryAssetConfigurationAuthToken,
+  CloudinaryAssetConfigurationCloud,
+  CloudinaryAssetConfigurationUrl,
 } from "./types/configuration.js";
-


### PR DESCRIPTION
# Description

I forgot to export the types I added in #191 - this also formats that index.ts file using default prettier settings

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
