### PR TITLE
feat: Add enum for format parameter

### DIFF
--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -45,7 +45,33 @@ export const assetOptionsSchema = z.object({
     )
     .optional(),
   format: z
-    .string()
+    .enum([
+      "auto",
+      "gif",
+      "png",
+      "jpg",
+      "bmp",
+      "ico",
+      "pdf",
+      "tiff",
+      "eps",
+      "jpc",
+      "jp2",
+      "psd",
+      "webp",
+      "zip",
+      "svg",
+      "webm",
+      "wdp",
+      "hpx",
+      "djvu",
+      "ai",
+      "flif",
+      "bpg",
+      "miff",
+      "tga",
+      "heic",
+    ])
     .default("auto")
     .describe(
       JSON.stringify({

--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -47,6 +47,8 @@ export const assetOptionsSchema = z.object({
   format: z
     .enum([
       "auto",
+      "auto:image",
+      "auto:animated",
       "gif",
       "png",
       "jpg",
@@ -71,6 +73,7 @@ export const assetOptionsSchema = z.object({
       "miff",
       "tga",
       "heic",
+      "default" // library specific feature to turn off automatic optimization
     ])
     .default("auto")
     .describe(


### PR DESCRIPTION
# Description

Add a list of allowable strings as an enum type for the format parameter.

## Issue Ticket Number

Fixes #142 

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
