### PR TITLE
Add `auto_pad` Crop Mode to the Cropping Plugin

### DIFF
--- a/packages/url-loader/src/constants/parameters.ts
+++ b/packages/url-loader/src/constants/parameters.ts
@@ -6,6 +6,7 @@ import type { StringifiablePrimative } from "../lib/utils.js";
  */
 export type CropMode =
   | "auto"
+  | "auto_pad"
   | "crop"
   | "fill"
   | "fill_pad"

--- a/packages/url-loader/src/plugins/cropping.ts
+++ b/packages/url-loader/src/plugins/cropping.ts
@@ -13,8 +13,8 @@ import { plugin } from "../lib/plugin.js";
 import { isArray } from "../lib/utils.js";
 import type { PluginResults } from "../types/plugins.js";
 
-const cropsAspectRatio = ["auto", "crop", "fill", "lfill", "fill_pad", "thumb"];
-const cropsGravityAuto = ["auto", "crop", "fill", "lfill", "fill_pad", "thumb"];
+const cropsAspectRatio = ["auto", "auto_pad", "crop", "fill", "lfill", "fill_pad", "thumb"];
+const cropsGravityAuto = ["auto", "auto_pad", "crop", "fill", "lfill", "fill_pad", "thumb"];
 const cropsWithZoom = ["crop", "thumb"];
 
 const DEFAULT_CROP = "limit";

--- a/packages/url-loader/tests/plugins/cropping.spec.ts
+++ b/packages/url-loader/tests/plugins/cropping.spec.ts
@@ -411,4 +411,60 @@ describe("Cropping plugin", () => {
       `image/upload/c_${options.crop.type},w_${options.width},h_${options.height},x_${options.crop.x},y_${options.crop.y}`,
     );
   });
+
+  it("should apply auto_pad crop mode with explicit gravity auto", () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      src: TEST_PUBLIC_ID,
+      width: 960,
+      aspectRatio: "16:9",
+      crop: "auto_pad",
+      gravity: "auto",
+    } as const;
+    const result = CroppingPlugin.apply(cldImage, options);
+
+    if (result.options?.resize === undefined)
+      throw new Error(`Expected result.options.resize to not be undefined`);
+
+    expect(result.options?.resize).toBe(
+      `c_auto_pad,ar_16:9,w_960,g_auto`,
+    );
+  });
+
+  it("should apply auto_pad crop mode with auto gravity by default", () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      src: TEST_PUBLIC_ID,
+      width: 960,
+      aspectRatio: "16:9",
+      crop: "auto_pad",
+    } as const;
+    const result = CroppingPlugin.apply(cldImage, options);
+
+    if (result.options?.resize === undefined)
+      throw new Error(`Expected result.options.resize to not be undefined`);
+
+    expect(result.options?.resize).toBe(
+      `c_auto_pad,ar_16:9,w_960,g_auto`,
+    );
+  });
+
+  it("should apply auto_pad crop mode with width and height", () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      src: TEST_PUBLIC_ID,
+      width: 960,
+      height: 540,
+      crop: "auto_pad",
+      gravity: "auto",
+    } as const;
+    const result = CroppingPlugin.apply(cldImage, options);
+
+    if (result.options?.resize === undefined)
+      throw new Error(`Expected result.options.resize to not be undefined`);
+
+    expect(result.options?.resize).toBe(
+      `c_auto_pad,w_960,h_540,g_auto`,
+    );
+  });
 });


### PR DESCRIPTION
# Description

<!-- Include a summary of the change made and also list the dependencies that are required if any -->

Added support for the `auto_pad` crop mode in the Cloudinary URL loader's cropping plugin. It allows users to specify `auto_pad` as crop type, which applies automatic padding as mentioned in the [documentation](https://cloudinary.com/documentation/transformation_reference#c_auto_pad).

### changes:
 - Added `"auto_pad"` in the `cropsAspectRatio` and `cropsGravityAuto` arrays in the `cropping.ts` to ensure correct handling of aspect ratio and gravity for this crop mode.
 - Added 3 tests for the following scenarios: 1. `auto_pad` crop mode applies with explicit gravity `auto`, 2. `auto_pad` crop mode defaults to gravity `auto` when not specified, and 3. `auto_pad` works with both aspect ratio and explicit width/height options. 

## Issue Ticket Number

Fixes #237 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
